### PR TITLE
Fix wrong hyperlink in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can purchase a premade version [here on our etsy page](https://www.etsy.com/
 
 ## Links
 
-- [Installation instructions](https://github.com/CapraAudio/CapraStrapra-Hifiman/blob/main/Install-Instructions.md)
+- [Installation instructions](https://github.com/CapraAudio/CapraStrapra-Beyerdynamic/blob/main/Install-Instructions.md)
 - [Printing instructions](https://github.com/CapraAudio/CapraStrapra-Beyerdynamic/blob/main/Printing-Instructions.md)
 - [Support Discord](https://discord.com/invite/fb4HdDvErF)
 - [Etsy Page](https://www.etsy.com/listing/1606114182/beyerdynamic-comfort-strap)


### PR DESCRIPTION
Changes the installation instruction link to Beyerdynamic instead of Hifiman.